### PR TITLE
Fix Python dependency pinning is too strict

### DIFF
--- a/recipe/3759.patch
+++ b/recipe/3759.patch
@@ -1,0 +1,22 @@
+From 8fabd1e8cc3e0161ff4935fcb4b1e7b6ae659e14 Mon Sep 17 00:00:00 2001
+From: Silvio Traversaro <silvio@traversaro.it>
+Date: Tue, 29 Jul 2025 15:52:02 +0200
+Subject: [PATCH] pxrConfig.cmake.in : Do not pin exact Python patch version
+
+---
+ pxr/pxrConfig.cmake.in | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/pxr/pxrConfig.cmake.in b/pxr/pxrConfig.cmake.in
+index ae8d02c5c0..951ce5f7a2 100644
+--- a/pxr/pxrConfig.cmake.in
++++ b/pxr/pxrConfig.cmake.in
+@@ -43,7 +43,7 @@ if(@PXR_ENABLE_PYTHON_SUPPORT@)
+     endif()
+ 
+     if (NOT DEFINED Python3_VERSION)
+-        find_dependency(Python3 "@Python3_VERSION@" EXACT COMPONENTS Development)
++        find_dependency(Python3 "@Python3_VERSION_MAJOR@.@Python3_VERSION_MINOR@" EXACT COMPONENTS Development)
+     else()
+         find_dependency(Python3 COMPONENTS Development)
+     endif()

--- a/recipe/recipe.yaml
+++ b/recipe/recipe.yaml
@@ -16,9 +16,11 @@ source:
       - add_pxr_install_dll_in_bin.patch
       # Needed for vs2022 compat
       - 3539.patch
+      # Fix https://github.com/conda-forge/openusd-feedstock/issues/11
+      - 3759.patch
 
 build:
-  number: 1
+  number: 2
 
 requirements:
   build:


### PR DESCRIPTION
<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [ ] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
