### PR TITLE
Remove unused boost dependency; OpenUSD vendors its own pxr_boost

### DIFF
--- a/.ci_support/linux_64_python3.10.____cpython.yaml
+++ b/.ci_support/linux_64_python3.10.____cpython.yaml
@@ -16,8 +16,6 @@ cxx_compiler_version:
 - '14'
 docker_image:
 - quay.io/condaforge/linux-anvil-x86_64:alma9
-libboost_devel:
-- '1.90'
 pin_run_as_build:
   python:
     min_pin: x.x

--- a/.ci_support/linux_64_python3.11.____cpython.yaml
+++ b/.ci_support/linux_64_python3.11.____cpython.yaml
@@ -16,8 +16,6 @@ cxx_compiler_version:
 - '14'
 docker_image:
 - quay.io/condaforge/linux-anvil-x86_64:alma9
-libboost_devel:
-- '1.90'
 pin_run_as_build:
   python:
     min_pin: x.x

--- a/.ci_support/linux_64_python3.12.____cpython.yaml
+++ b/.ci_support/linux_64_python3.12.____cpython.yaml
@@ -16,8 +16,6 @@ cxx_compiler_version:
 - '14'
 docker_image:
 - quay.io/condaforge/linux-anvil-x86_64:alma9
-libboost_devel:
-- '1.90'
 pin_run_as_build:
   python:
     min_pin: x.x

--- a/.ci_support/linux_64_python3.13.____cp313.yaml
+++ b/.ci_support/linux_64_python3.13.____cp313.yaml
@@ -16,8 +16,6 @@ cxx_compiler_version:
 - '14'
 docker_image:
 - quay.io/condaforge/linux-anvil-x86_64:alma9
-libboost_devel:
-- '1.90'
 pin_run_as_build:
   python:
     min_pin: x.x

--- a/.ci_support/linux_64_python3.14.____cp314.yaml
+++ b/.ci_support/linux_64_python3.14.____cp314.yaml
@@ -16,8 +16,6 @@ cxx_compiler_version:
 - '14'
 docker_image:
 - quay.io/condaforge/linux-anvil-x86_64:alma9
-libboost_devel:
-- '1.90'
 pin_run_as_build:
   python:
     min_pin: x.x

--- a/.ci_support/linux_aarch64_python3.10.____cpython.yaml
+++ b/.ci_support/linux_aarch64_python3.10.____cpython.yaml
@@ -16,8 +16,6 @@ cxx_compiler_version:
 - '14'
 docker_image:
 - quay.io/condaforge/linux-anvil-x86_64:alma9
-libboost_devel:
-- '1.90'
 pin_run_as_build:
   python:
     min_pin: x.x

--- a/.ci_support/linux_aarch64_python3.11.____cpython.yaml
+++ b/.ci_support/linux_aarch64_python3.11.____cpython.yaml
@@ -16,8 +16,6 @@ cxx_compiler_version:
 - '14'
 docker_image:
 - quay.io/condaforge/linux-anvil-x86_64:alma9
-libboost_devel:
-- '1.90'
 pin_run_as_build:
   python:
     min_pin: x.x

--- a/.ci_support/linux_aarch64_python3.12.____cpython.yaml
+++ b/.ci_support/linux_aarch64_python3.12.____cpython.yaml
@@ -16,8 +16,6 @@ cxx_compiler_version:
 - '14'
 docker_image:
 - quay.io/condaforge/linux-anvil-x86_64:alma9
-libboost_devel:
-- '1.90'
 pin_run_as_build:
   python:
     min_pin: x.x

--- a/.ci_support/linux_aarch64_python3.13.____cp313.yaml
+++ b/.ci_support/linux_aarch64_python3.13.____cp313.yaml
@@ -16,8 +16,6 @@ cxx_compiler_version:
 - '14'
 docker_image:
 - quay.io/condaforge/linux-anvil-x86_64:alma9
-libboost_devel:
-- '1.90'
 pin_run_as_build:
   python:
     min_pin: x.x

--- a/.ci_support/linux_aarch64_python3.14.____cp314.yaml
+++ b/.ci_support/linux_aarch64_python3.14.____cp314.yaml
@@ -16,8 +16,6 @@ cxx_compiler_version:
 - '14'
 docker_image:
 - quay.io/condaforge/linux-anvil-x86_64:alma9
-libboost_devel:
-- '1.90'
 pin_run_as_build:
   python:
     min_pin: x.x

--- a/.ci_support/osx_64_python3.10.____cpython.yaml
+++ b/.ci_support/osx_64_python3.10.____cpython.yaml
@@ -18,8 +18,6 @@ cxx_compiler:
 - clangxx
 cxx_compiler_version:
 - '19'
-libboost_devel:
-- '1.90'
 macos_machine:
 - x86_64-apple-darwin13.4.0
 pin_run_as_build:

--- a/.ci_support/osx_64_python3.11.____cpython.yaml
+++ b/.ci_support/osx_64_python3.11.____cpython.yaml
@@ -18,8 +18,6 @@ cxx_compiler:
 - clangxx
 cxx_compiler_version:
 - '19'
-libboost_devel:
-- '1.90'
 macos_machine:
 - x86_64-apple-darwin13.4.0
 pin_run_as_build:

--- a/.ci_support/osx_64_python3.12.____cpython.yaml
+++ b/.ci_support/osx_64_python3.12.____cpython.yaml
@@ -18,8 +18,6 @@ cxx_compiler:
 - clangxx
 cxx_compiler_version:
 - '19'
-libboost_devel:
-- '1.90'
 macos_machine:
 - x86_64-apple-darwin13.4.0
 pin_run_as_build:

--- a/.ci_support/osx_64_python3.13.____cp313.yaml
+++ b/.ci_support/osx_64_python3.13.____cp313.yaml
@@ -18,8 +18,6 @@ cxx_compiler:
 - clangxx
 cxx_compiler_version:
 - '19'
-libboost_devel:
-- '1.90'
 macos_machine:
 - x86_64-apple-darwin13.4.0
 pin_run_as_build:

--- a/.ci_support/osx_64_python3.14.____cp314.yaml
+++ b/.ci_support/osx_64_python3.14.____cp314.yaml
@@ -18,8 +18,6 @@ cxx_compiler:
 - clangxx
 cxx_compiler_version:
 - '19'
-libboost_devel:
-- '1.90'
 macos_machine:
 - x86_64-apple-darwin13.4.0
 pin_run_as_build:

--- a/.ci_support/osx_arm64_python3.10.____cpython.yaml
+++ b/.ci_support/osx_arm64_python3.10.____cpython.yaml
@@ -18,8 +18,6 @@ cxx_compiler:
 - clangxx
 cxx_compiler_version:
 - '19'
-libboost_devel:
-- '1.90'
 macos_machine:
 - arm64-apple-darwin20.0.0
 pin_run_as_build:

--- a/.ci_support/osx_arm64_python3.11.____cpython.yaml
+++ b/.ci_support/osx_arm64_python3.11.____cpython.yaml
@@ -18,8 +18,6 @@ cxx_compiler:
 - clangxx
 cxx_compiler_version:
 - '19'
-libboost_devel:
-- '1.90'
 macos_machine:
 - arm64-apple-darwin20.0.0
 pin_run_as_build:

--- a/.ci_support/osx_arm64_python3.12.____cpython.yaml
+++ b/.ci_support/osx_arm64_python3.12.____cpython.yaml
@@ -18,8 +18,6 @@ cxx_compiler:
 - clangxx
 cxx_compiler_version:
 - '19'
-libboost_devel:
-- '1.90'
 macos_machine:
 - arm64-apple-darwin20.0.0
 pin_run_as_build:

--- a/.ci_support/osx_arm64_python3.13.____cp313.yaml
+++ b/.ci_support/osx_arm64_python3.13.____cp313.yaml
@@ -18,8 +18,6 @@ cxx_compiler:
 - clangxx
 cxx_compiler_version:
 - '19'
-libboost_devel:
-- '1.90'
 macos_machine:
 - arm64-apple-darwin20.0.0
 pin_run_as_build:

--- a/.ci_support/osx_arm64_python3.14.____cp314.yaml
+++ b/.ci_support/osx_arm64_python3.14.____cp314.yaml
@@ -18,8 +18,6 @@ cxx_compiler:
 - clangxx
 cxx_compiler_version:
 - '19'
-libboost_devel:
-- '1.90'
 macos_machine:
 - arm64-apple-darwin20.0.0
 pin_run_as_build:

--- a/.ci_support/win_64_python3.10.____cpython.yaml
+++ b/.ci_support/win_64_python3.10.____cpython.yaml
@@ -8,8 +8,6 @@ channel_targets:
 - conda-forge main
 cxx_compiler:
 - vs2022
-libboost_devel:
-- '1.90'
 pin_run_as_build:
   python:
     min_pin: x.x

--- a/.ci_support/win_64_python3.11.____cpython.yaml
+++ b/.ci_support/win_64_python3.11.____cpython.yaml
@@ -8,8 +8,6 @@ channel_targets:
 - conda-forge main
 cxx_compiler:
 - vs2022
-libboost_devel:
-- '1.90'
 pin_run_as_build:
   python:
     min_pin: x.x

--- a/.ci_support/win_64_python3.12.____cpython.yaml
+++ b/.ci_support/win_64_python3.12.____cpython.yaml
@@ -8,8 +8,6 @@ channel_targets:
 - conda-forge main
 cxx_compiler:
 - vs2022
-libboost_devel:
-- '1.90'
 pin_run_as_build:
   python:
     min_pin: x.x

--- a/.ci_support/win_64_python3.13.____cp313.yaml
+++ b/.ci_support/win_64_python3.13.____cp313.yaml
@@ -8,8 +8,6 @@ channel_targets:
 - conda-forge main
 cxx_compiler:
 - vs2022
-libboost_devel:
-- '1.90'
 pin_run_as_build:
   python:
     min_pin: x.x

--- a/.ci_support/win_64_python3.14.____cp314.yaml
+++ b/.ci_support/win_64_python3.14.____cp314.yaml
@@ -8,8 +8,6 @@ channel_targets:
 - conda-forge main
 cxx_compiler:
 - vs2022
-libboost_devel:
-- '1.90'
 pin_run_as_build:
   python:
     min_pin: x.x

--- a/recipe/recipe.yaml
+++ b/recipe/recipe.yaml
@@ -19,7 +19,7 @@ source:
       - remove_hardcoded_prefix.patch
 
 build:
-  number: 0
+  number: 1
   skip: ppc64le
 
 requirements:
@@ -42,7 +42,6 @@ requirements:
         - xorg-libxrandr
     - glfw
     - tbb-devel
-    - libboost-devel
     - libopensubdiv
     - python
     - jinja2
@@ -53,7 +52,7 @@ requirements:
     # Without tbb-devel, CMake's find_package(pxr REQUIRED) fails
     # Furthermore, openusd exposes internal header-only symbols of tbb in its public headers/public symbols,
     # so even if the tbb itself is ABI stable, we need to pin the major minor version of tbb-devel to ensure that
-    # the symbols contained in the library match the one that the downstream consumers expect to use, see 
+    # the symbols contained in the library match the one that the downstream consumers expect to use, see
     # https://github.com/conda-forge/openusd-feedstock/issues/9 for more details
     - ${{ pin_compatible('tbb-devel', upper_bound='x.x') }}
     # Required by usdview


### PR DESCRIPTION
OpenUSD 24.11+ replaced boost::python with a vendored, namespace-mangled pxr_boost and no longer links external boost in the default build. This recipe enables only PXR_ENABLE_PYTHON_SUPPORT (no OpenVDB/OpenImageIO), so nothing links libboost: all boost symbols resolve to the in-package libusd_boost, and the remaining <boost/...> includes in public headers are behind opt-in guards (PXR_BOOST_PYTHON_HAS_BOOST_SHARED_PTR, PEGTL's legacy-compiler fallback).

libboost-devel is kept in host for the build, but its run-export is ignored since the built libraries link only the vendored libusd_boost, never external libboost. (Note: this still leaves openusd subject to boost-migration rebuilds, which become no-ops.) Bump build number for the rebuild.

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
